### PR TITLE
fix(cors): allow Capacitor localhost origin

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -286,6 +286,7 @@ app.use((req, res, next) => {
   const extraOrigins = (process.env.ALLOWED_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean);
   const allowedOrigins = [
     'http://localhost:5173', 'http://127.0.0.1:5173',
+    'https://localhost', 'https://127.0.0.1',
     `http://localhost:${CONFIG.port}`, `http://127.0.0.1:${CONFIG.port}`,
     ...extraOrigins,
   ];


### PR DESCRIPTION
问题：APK 页面 Origin 为 https://localhost，访问 http://192.168.10.3:3210 时 /api/connect 预检未放行，导致输入 token 后无法进入。

测试：Origin=https://localhost 的 OPTIONS /api/connect 现返回 Access-Control-Allow-Origin。