### PR TITLE
fix(webui): 修复回答重复渲染

### DIFF
--- a/h5/src/main.js
+++ b/h5/src/main.js
@@ -167,9 +167,11 @@ function doConnect(host, token, errorEl, connectBtn) {
 
   // 超时处理
   let done = false
+  let unsub = null
   const timeout = setTimeout(() => {
     if (done) return
     done = true
+    if (unsub) unsub()
     errorEl.textContent = t('setup.error.timeout')
     connectBtn.disabled = false
     connectBtn.textContent = t('setup.connect')
@@ -178,7 +180,7 @@ function doConnect(host, token, errorEl, connectBtn) {
   }, 20000)
 
   // 一次性监听就绪
-  const unsub = wsClient.onReady(() => {
+  unsub = wsClient.onReady(() => {
     if (done) return
     done = true
     clearTimeout(timeout)


### PR DESCRIPTION
现象：在 192.168.10.3 局域网部署场景下（手机同网段访问 WebUI），AI 回复会大概率重复渲染。 
原因：SSE 重复投递 + 事件订阅重复绑定 + lifecycle end 与 chat.final 时序竞态叠加，导致同一终态被重复消费。 
解决后结果：加入 SSE/终态去重并修正订阅与状态流转后，手机同网段实测不再重复渲染。