### PR TITLE
fix: 刷新后恢复会话忙碌状态与加载动效

### DIFF
--- a/h5/src/api-client.js
+++ b/h5/src/api-client.js
@@ -350,6 +350,31 @@ export class WsClient {
     return this.request('sessions.reset', { key })
   }
 
+  async getSessionProgress(sessionKey, options = {}) {
+    if (!this._baseUrl) throw new Error('未连接')
+    const preferSessionKey = !!options.preferSessionKey
+    const query = new URLSearchParams()
+    if (sessionKey) query.set('sessionKey', sessionKey)
+    if (this._sid && !preferSessionKey) query.set('sid', this._sid)
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT)
+    try {
+      const res = await fetch(`${this._baseUrl}/api/progress?${query.toString()}`, {
+        method: 'GET',
+        signal: controller.signal,
+      })
+      clearTimeout(timer)
+      const data = await res.json()
+      if (!data.ok) throw new Error(data.error || '获取进度失败')
+      return data
+    } catch (e) {
+      clearTimeout(timer)
+      if (e.name === 'AbortError') throw new Error('查询进度超时')
+      throw e
+    }
+  }
+
   // ==================== 内部辅助 ====================
 
   _setConnected(val, status, errorMsg) {

--- a/h5/src/chat-ui.js
+++ b/h5/src/chat-ui.js
@@ -7,6 +7,7 @@ import { initSettings, showSettings } from './settings.js'
 import { saveMessage, saveMessages, getLocalMessages, clearSessionMessages, isStorageAvailable, saveSessionInfo } from './message-db.js'
 
 const STORAGE_SESSION_KEY = 'clawapp-session-key'
+const STORAGE_PENDING_KEY = 'clawapp-pending-sessions'
 
 let _messagesEl = null
 let _typingEl = null
@@ -152,6 +153,57 @@ export function setSessionKey(key) {
 }
 export function getSessionKey() { return _sessionKey }
 
+function readPendingSessions() {
+  try {
+    const raw = localStorage.getItem(STORAGE_PENDING_KEY)
+    const parsed = raw ? JSON.parse(raw) : {}
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function writePendingSessions(map) {
+  try {
+    localStorage.setItem(STORAGE_PENDING_KEY, JSON.stringify(map || {}))
+  } catch {}
+}
+
+function markSessionPending(pending) {
+  if (!_sessionKey) return
+  const map = readPendingSessions()
+  if (pending) map[_sessionKey] = Date.now()
+  else delete map[_sessionKey]
+  writePendingSessions(map)
+}
+
+function isSessionMarkedPending() {
+  if (!_sessionKey) return false
+  const map = readPendingSessions()
+  return !!map[_sessionKey]
+}
+
+async function restorePendingIndicator() {
+  if (!_sessionKey) return
+  const localPending = isSessionMarkedPending()
+  if (localPending) showTyping(true)
+
+  try {
+    const progress = await wsClient.getSessionProgress(_sessionKey, { preferSessionKey: true })
+    if (progress?.busy) {
+      showTyping(true)
+      markSessionPending(true)
+      return
+    }
+    if (localPending) {
+      showTyping(false)
+      markSessionPending(false)
+    }
+  } catch (e) {
+    console.warn('[chat] restorePendingIndicator failed:', e)
+  }
+}
+
 export function initChatUI(onSettings) {
   _messagesEl = document.getElementById('chat-messages')
   _typingEl = document.getElementById('typing-indicator')
@@ -204,6 +256,7 @@ export function initChatUI(onSettings) {
     if (status === 'ready' || status === 'connected') {
       dot.classList.add('connected')
       hideDisconnectBanner()
+      restorePendingIndicator().catch(() => {})
     } else if (status === 'connecting' || status === 'reconnecting') {
       dot.classList.add('connecting')
       showDisconnectBanner(true)
@@ -212,6 +265,8 @@ export function initChatUI(onSettings) {
       showDisconnectBanner(false)
     }
   })
+
+  restorePendingIndicator().catch(() => {})
 }
 
 function toggleVoiceInput(SR) {
@@ -335,6 +390,7 @@ async function doSend(text, attachments) {
     saveMessage({ id: uuid(), sessionKey: _sessionKey, role: 'user', content: text, attachments: attachments?.length ? attachments : undefined, timestamp: Date.now() })
   }
   showTyping(true)
+  markSessionPending(true)
   _isSending = true
   _textarea.disabled = true
 
@@ -342,6 +398,7 @@ async function doSend(text, attachments) {
     await wsClient.chatSend(_sessionKey, text, attachments.length ? attachments : undefined)
   } catch (err) {
     showTyping(false)
+    markSessionPending(false)
     if (isSessionMissingError(err.message)) {
       fallbackToDefaultSessionWithNotice()
       return
@@ -365,11 +422,13 @@ function processMessageQueue() {
   const next = _messageQueue.shift()
   // 用户消息已经在入队时 append 过了，这里不再 append
   showTyping(true)
+  markSessionPending(true)
   _isSending = true
   _textarea.disabled = true
   wsClient.chatSend(_sessionKey, next.text, next.attachments?.length ? next.attachments : undefined)
     .catch(err => {
       showTyping(false)
+      markSessionPending(false)
       if (isSessionMissingError(err.message)) {
         fallbackToDefaultSessionWithNotice()
         return
@@ -520,6 +579,7 @@ function handleChatEvent(payload) {
     }
     // 非流式状态，终态错误
     showTyping(false)
+    markSessionPending(false)
     appendSystemMessage(`${t('chat.error.prefix')}: ${errMsg}`)
     resetStreamState()
     processMessageQueue()
@@ -618,6 +678,7 @@ function resetStreamState() {
   _currentRunId = null
   _isStreaming = false
   _toolCards.clear()
+  markSessionPending(false)
   updateSendState()
 }
 
@@ -1322,7 +1383,10 @@ function switchSession(newKey) {
   resetStreamState()
   updateSessionTitle()
   showLoadingOverlay()
-  loadHistory().finally(() => hideLoadingOverlay())
+  loadHistory().finally(() => {
+    hideLoadingOverlay()
+    restorePendingIndicator().catch(() => {})
+  })
 }
 
 /** 加载遮罩 */

--- a/server/index.js
+++ b/server/index.js
@@ -72,6 +72,18 @@ const REQUEST_TIMEOUT = 30000;
 const CONNECT_TIMEOUT = 10000;
 const GATEWAY_RETRY_COUNT = 3;
 const GATEWAY_RETRY_DELAY = 1000;
+const PROGRESS_STALE_TIMEOUT = 120000;
+
+function setSessionProgress(session, patch = {}) {
+  session.progress = {
+    isBusy: session.progress?.isBusy || false,
+    sessionKey: session.progress?.sessionKey || '',
+    runId: session.progress?.runId || '',
+    state: session.progress?.state || 'idle',
+    updatedAt: Date.now(),
+    ...patch,
+  };
+}
 
 /**
  * 生成 connect 握手帧（含 Ed25519 device 签名）
@@ -173,6 +185,47 @@ function handleUpstreamMessage(sid, rawData) {
 
     // 事件 → 推送 SSE（统一用 message 事件名，原始事件类型在 data 中）
     if (msg.type === 'event') {
+      if (msg.event === 'chat') {
+        const payload = msg.payload || {};
+        const state = payload.state;
+        if (state === 'delta') {
+          setSessionProgress(session, {
+            isBusy: true,
+            sessionKey: payload.sessionKey || session.progress?.sessionKey || '',
+            runId: payload.runId || session.progress?.runId || '',
+            state: 'streaming',
+          });
+        } else if (state === 'final' || state === 'error' || state === 'aborted') {
+          setSessionProgress(session, {
+            isBusy: false,
+            sessionKey: payload.sessionKey || session.progress?.sessionKey || '',
+            runId: payload.runId || session.progress?.runId || '',
+            state,
+          });
+        }
+      }
+
+      if (msg.event === 'agent') {
+        const payload = msg.payload || {};
+        const stream = payload.stream;
+        const phase = payload.data?.phase;
+        if (stream === 'lifecycle' && phase === 'start') {
+          setSessionProgress(session, {
+            isBusy: true,
+            sessionKey: payload.sessionKey || session.progress?.sessionKey || '',
+            runId: payload.runId || session.progress?.runId || '',
+            state: 'lifecycle.start',
+          });
+        } else if (stream === 'lifecycle' && phase === 'end') {
+          setSessionProgress(session, {
+            isBusy: false,
+            sessionKey: payload.sessionKey || session.progress?.sessionKey || '',
+            runId: payload.runId || session.progress?.runId || '',
+            state: 'lifecycle.end',
+          });
+        }
+      }
+
       log.debug(`SSE 推送 [${sid}] event=${msg.event} stream=${msg.payload?.stream} phase=${msg.payload?.data?.phase} state=${msg.payload?.state}`);
       sseWrite(session, 'message', msg);
     }
@@ -373,6 +426,13 @@ app.post('/api/connect', async (req, res) => {
     _heartbeat: null,
     _lingerTimer: null,
     _sseHeartbeat: null,
+    progress: {
+      isBusy: false,
+      sessionKey: '',
+      runId: '',
+      state: 'idle',
+      updatedAt: Date.now(),
+    },
   };
   sessions.set(sid, session);
 
@@ -496,6 +556,55 @@ app.get('/api/events', (req, res) => {
   });
 });
 
+/** GET /api/progress — 查询会话执行状态（用于刷新后恢复 loading） */
+app.get('/api/progress', (req, res) => {
+  const sid = String(req.query.sid || '');
+  const sessionKey = String(req.query.sessionKey || '');
+
+  const toResponse = (sourceSid, progress) => {
+    const now = Date.now();
+    const updatedAt = Number(progress?.updatedAt || 0);
+    const stale = updatedAt > 0 && (now - updatedAt > PROGRESS_STALE_TIMEOUT);
+    const busy = !!progress?.isBusy && !stale;
+    return res.json({
+      ok: true,
+      sid: sourceSid || '',
+      sessionKey: progress?.sessionKey || sessionKey || '',
+      busy,
+      runId: progress?.runId || '',
+      state: stale ? 'stale' : (progress?.state || 'idle'),
+      updatedAt: updatedAt || now,
+      stale,
+    });
+  };
+
+  if (sid) {
+    const session = sessions.get(sid);
+    if (!session) return res.status(404).json({ ok: false, error: '会话不存在' });
+    return toResponse(sid, session.progress || {});
+  }
+
+  if (sessionKey) {
+    for (const [activeSid, session] of sessions) {
+      if ((session.progress?.sessionKey || '') === sessionKey) {
+        return toResponse(activeSid, session.progress || {});
+      }
+    }
+    return res.json({
+      ok: true,
+      sid: '',
+      sessionKey,
+      busy: false,
+      runId: '',
+      state: 'idle',
+      updatedAt: Date.now(),
+      stale: false,
+    });
+  }
+
+  return res.status(400).json({ ok: false, error: '缺少 sid 或 sessionKey' });
+});
+
 /** POST /api/send — 发送请求（RPC 转发） */
 app.post('/api/send', async (req, res) => {
   const { sid, method, params } = req.body || {};
@@ -515,6 +624,15 @@ app.post('/api/send', async (req, res) => {
 
   log.info(`RPC 请求 [${sid}] id=${reqId} method=${method}`);
   const frame = { type: 'req', id: reqId, method, params };
+
+  if (method === 'chat.send') {
+    setSessionProgress(session, {
+      isBusy: true,
+      sessionKey: params?.sessionKey || session.progress?.sessionKey || '',
+      runId: '',
+      state: 'sending',
+    });
+  }
 
   try {
     const result = await new Promise((resolve, reject) => {


### PR DESCRIPTION
新增服务端会话进度查询接口，支持按 sessionKey 判断会话 busy 状态。

前端在连接就绪与会话切换后主动拉取进度，恢复或关闭‘...’加载动效。

修复刷新后因 sid 变化导致 busy 状态判断错误的问题。并且知道openclaw还在处理会话。